### PR TITLE
chore: fix typo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "quaero-form",
+      "name": "Quaero form",
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",


### PR DESCRIPTION
Fixes a minor typo in `package-lock.json` by correcting the package name casing.

## Changes

* Corrected package name from `quaero-form` to `Quaero_form` in `package-lock.json`
